### PR TITLE
Qza load at process start

### DIFF
--- a/microsetta_public_api/__init__.py
+++ b/microsetta_public_api/__init__.py
@@ -1,2 +1,2 @@
-__all__ = ['server', 'api', 'config',
+__all__ = ['server', 'api', 'config', 'exceptions',
            ]

--- a/microsetta_public_api/config.py
+++ b/microsetta_public_api/config.py
@@ -1,1 +1,38 @@
-resources = dict()
+import os
+from microsetta_public_api.exceptions import ConfigurationError
+
+
+class ResourcesConfig(dict):
+
+    resource_fields = ['alpha_resources']
+
+    def update(self, _m, **kwargs):
+
+        for resource_field in self.resource_fields:
+            if resource_field in self:
+                self._validate_resource_locations(self[resource_field])
+
+        super().update(_m, **kwargs)
+
+    @staticmethod
+    def _validate_resource_locations(resource_locations):
+        if not isinstance(resource_locations, dict):
+            raise ConfigurationError('resource_locations must be '
+                                     'able to be parsed into a python '
+                                     'dictionary.')
+        all_keys_str = all(isinstance(key, str) for key in
+                           resource_locations)
+        if not all_keys_str:
+            raise ConfigurationError('All `alpha_resources` keys must be '
+                                     'strings.')
+        all_values_fp = all(os.path.exists(val) for val in
+                            resource_locations.values())
+        if not all_values_fp:
+            raise ConfigurationError('All `alpha_resources` values must be '
+                                     'existing file paths.')
+        return True
+
+    pass
+
+
+resources = ResourcesConfig()

--- a/microsetta_public_api/config.py
+++ b/microsetta_public_api/config.py
@@ -12,7 +12,7 @@ class ResourcesConfig(dict):
             if resource_field in self:
                 self._validate_resource_locations(self[resource_field])
 
-        super().update(_m, **kwargs)
+        return super().update(_m, **kwargs)
 
     @staticmethod
     def _validate_resource_locations(resource_locations):

--- a/microsetta_public_api/repo/_alpha_repo.py
+++ b/microsetta_public_api/repo/_alpha_repo.py
@@ -2,7 +2,6 @@ from microsetta_public_api import config
 from microsetta_public_api.exceptions import ConfigurationError, UnknownMetric
 from qiime2 import Artifact
 from q2_types.sample_data import AlphaDiversity, SampleData
-import os
 import pandas as pd
 
 
@@ -16,27 +15,8 @@ class AlphaRepo:
     def __init__(self):
         self.resource_locations = config.resources.get('alpha_resources', None)
         if self.resource_locations is not None:
-            self._validate_resource_locations(self.resource_locations)
             # leaving as None here allows lazy loading of resources
             self.resources = {key: None for key in self.resource_locations}
-
-    @staticmethod
-    def _validate_resource_locations(resource_locations):
-        if not isinstance(resource_locations, dict):
-            raise ConfigurationError('`alpha_resources` must be '
-                                     'able to be parsed into a python '
-                                     'dictionary.')
-        all_keys_str = all(isinstance(key, str) for key in
-                           resource_locations)
-        if not all_keys_str:
-            raise ConfigurationError('All `alpha_resources` keys must be '
-                                     'strings.')
-        all_values_fp = all(os.path.exists(val) for val in
-                            resource_locations.values())
-        if not all_values_fp:
-            raise ConfigurationError('All `alpha_resources` values must be '
-                                     'existing file paths.')
-        return True
 
     def _load_resource(self, metric):
         if metric not in self.available_metrics():

--- a/microsetta_public_api/repo/_alpha_repo.py
+++ b/microsetta_public_api/repo/_alpha_repo.py
@@ -1,8 +1,5 @@
-from microsetta_public_api import config
-from microsetta_public_api.exceptions import ConfigurationError, UnknownMetric
-from qiime2 import Artifact
-from q2_types.sample_data import AlphaDiversity, SampleData
-import pandas as pd
+from microsetta_public_api.exceptions import UnknownMetric
+from microsetta_public_api.resources import resources
 
 
 class AlphaRepo:
@@ -13,37 +10,19 @@ class AlphaRepo:
     resource_locations = None
 
     def __init__(self):
-        self.resource_locations = config.resources.get('alpha_resources', None)
-        if self.resource_locations is not None:
-            # leaving as None here allows lazy loading of resources
-            self.resources = {key: None for key in self.resource_locations}
+        self.resources = resources.get('alpha_resources', dict())
+        # if self.resource_locations is not None:
+        #     # leaving as None here allows lazy loading of resources
+        #     def f(x): return self._parse_q2_data(self.resource_locations[x])
+        #     self.resources = {key: f(key) for key in self.resource_locations}
 
-    def _load_resource(self, metric):
+    def _get_resource(self, metric):
         if metric not in self.available_metrics():
             raise UnknownMetric(f"No resource available for metric="
                                 f"'{metric}'")
         else:
-            res = self.resources[metric]
-            if res is None:
-                # TODO could have a more sophisticated parser here,
-                #  where multiple file types are accepted, but will assumed qza
-                #  for now
-                res = self._parse_q2_data(self.resource_locations[metric])
+            res = self.resources.get(metric, None)
             return res
-
-    @staticmethod
-    def _parse_q2_data(filepath):
-        try:
-            data = Artifact.load(filepath)
-        except ValueError as e:
-            raise ConfigurationError(*e.args)
-
-        if data.type != SampleData[AlphaDiversity]:
-            raise ConfigurationError(f"Expected alpha diversity to have type "
-                                     f"'SampleData[AlphaDiversity]'. "
-                                     f"Received '{data.type}'.")
-
-        return data.view(pd.Series)
 
     def available_metrics(self):
         """Return the metrics that are available with this Repo
@@ -69,14 +48,14 @@ class AlphaRepo:
 
         Returns
         -------
-        pd.Series
+        pandas.Series
             Contains alpha diversity with metric `metric` for the
             union of samples ids in the database the ids in `sample_ids`.
             Sets the name of the series to `metric`.
 
         """
         # this could raise an UnknownMetric or ConfigurationError
-        alpha_series = self._load_resource(metric)
+        alpha_series = self._get_resource(metric)
         # TODO the following could throw KeyErrors if a sample id is not in
         #  the index. Right now, the API checks for missing ID's before
         #  calling this.
@@ -105,7 +84,7 @@ class AlphaRepo:
             in the database.
 
         """
-        alpha_series = self._load_resource(metric)
+        alpha_series = self._get_resource(metric)
         if isinstance(sample_ids, str):
             return sample_ids in alpha_series.index
         else:

--- a/microsetta_public_api/repo/tests/test_alpha_repo.py
+++ b/microsetta_public_api/repo/tests/test_alpha_repo.py
@@ -22,31 +22,6 @@ class TestAlphaRepoHelpers(TempfileTestCase):
                                                        "'fake-test-metric'"):
                 alpha_repo._load_resource('fake-test-metric')
 
-    def test_validate_resource_locations_non_dict(self):
-        resource_locations = ['alpha', 'beta']
-        alpha_repo = AlphaRepo()
-        with self.assertRaisesRegex(ConfigurationError, 'dictionary'):
-            alpha_repo._validate_resource_locations(resource_locations)
-
-    def test_validate_resource_locations_non_string_resource_key(self):
-        resource_locations = {9: '/some/file/path'}
-        alpha_repo = AlphaRepo()
-        with self.assertRaisesRegex(ConfigurationError, 'keys must be '
-                                                        'strings'):
-            alpha_repo._validate_resource_locations(resource_locations)
-
-    def test_validate_resource_locations_non_existing_resource_value(self):
-        file_ = self.create_tempfile()
-        # closing the file removes it from the filesystem
-        file_.close()
-
-        resource_locations = {'some-metric': file_.name}
-        alpha_repo = AlphaRepo()
-        with self.assertRaisesRegex(ConfigurationError, 'must be '
-                                                        'existing '
-                                                        'file paths'):
-            alpha_repo._validate_resource_locations(resource_locations)
-
     def test_parse_q2_data(self):
         resource_filename = self.create_tempfile(suffix='.qza').name
         test_series = pd.Series({'sample1': 7.15, 'sample2': 9.04},

--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -1,0 +1,83 @@
+import os
+import pandas as pd
+from copy import deepcopy
+from microsetta_public_api.exceptions import ConfigurationError
+from qiime2 import Artifact
+from q2_types.sample_data import AlphaDiversity, SampleData
+
+
+class ResourceManager(dict):
+
+    dict_of_qza_resources = {'alpha_resources': SampleData[AlphaDiversity]}
+
+    def update(self, other, **kwargs):
+        """
+        Updates the resources this manager has. If the resource field
+
+        Parameters
+        ----------
+        other : dict
+            Resource identifier to resource mapping. 'alpha_resources' is
+            reserved for a dictionary. The values in 'alpha_resources' must be
+            existing file paths with a .qza extension, they will be read
+            into a python QZA.
+        kwargs : dict
+            kwargs for dict.update. Similar to `other`, but can be passed as
+            keywords.
+
+        Returns
+        -------
+        NoneType
+
+        Examples
+        --------
+        >>> resources = ResourceManager(alpha_resources={
+        ...     {'faith_pd': '/path/to/some.qza',
+        ...      'chao1': '/another/path/to/a.qza',
+        ...     }}, some_other_resource='here is a string resource')
+
+
+        """
+        for resource_name, type_ in self.dict_of_qza_resources.items():
+            if resource_name in other:
+                other = self._replace_paths_with_qza(other, resource_name,
+                                                     type_)
+            if resource_name in kwargs:
+                kwargs = self._replace_paths_with_qza(kwargs, resource_name,
+                                                      type_)
+
+        return super().update(other, **kwargs)
+
+    def _replace_paths_with_qza(self, resource, name, semantic_type):
+        dict_of_qza_paths = resource[name]
+        if not isinstance(dict_of_qza_paths, dict):
+            raise ValueError(f"Expected '{name}' field to contain a dict. "
+                             f"Got {type(resource[name]).__name__}")
+        new_resource = deepcopy(resource)
+        for key, value in dict_of_qza_paths.items():
+            value_is_existing_qza_path = isinstance(value, str) and \
+                (value[-4:] == '.qza') and os.path.exists(value)
+            if value_is_existing_qza_path:
+                new_resource[name][key] = self._parse_q2_data(value,
+                                                              semantic_type)
+            else:
+                raise ValueError(f'Expected existing path with .qza '
+                                 f'extension. Got: {value}')
+        return new_resource
+
+    @staticmethod
+    def _parse_q2_data(filepath, semantic_type):
+        try:
+            data = Artifact.load(filepath)
+        except ValueError as e:
+            raise ConfigurationError(*e.args)
+
+        if data.type != semantic_type:
+            raise ConfigurationError(f"Expected QZA '{filepath}' to have type "
+                                     f"'{semantic_type}'. "
+                                     f"Received '{data.type}'.")
+
+        return data.view(pd.Series)
+
+
+resources = ResourceManager()

--- a/microsetta_public_api/server.py
+++ b/microsetta_public_api/server.py
@@ -1,6 +1,7 @@
 import json
 from pkg_resources import resource_filename
 from microsetta_public_api import config
+from microsetta_public_api.resources import resources
 
 import connexion
 
@@ -14,6 +15,8 @@ def build_app(resources_config_json=None):
     if resources_config_json is not None:
         resource_updates = json.load(resources_config_json)
         config.resources.update(resource_updates)
+
+        resources.update(config.resources)
 
     app_file = resource_filename('microsetta_public_api.api',
                                  'microsetta_public_api.yml')

--- a/microsetta_public_api/tests/test_config.py
+++ b/microsetta_public_api/tests/test_config.py
@@ -1,0 +1,34 @@
+from microsetta_public_api.utils.testing import TempfileTestCase
+from microsetta_public_api.config import ResourcesConfig
+from microsetta_public_api.exceptions import ConfigurationError
+
+
+class TestConfig(TempfileTestCase):
+
+    def test_validate_resource_locations_non_dict(self):
+        config = ResourcesConfig()
+        resource_locations = ['alpha', 'beta']
+        with self.assertRaisesRegex(ConfigurationError, 'dictionary'):
+            config._validate_resource_locations(resource_locations)
+
+
+    def test_validate_resource_locations_non_string_resource_key(self):
+        resource_locations = {9: '/some/file/path'}
+        config = ResourcesConfig()
+        with self.assertRaisesRegex(ConfigurationError, 'keys must be '
+                                                        'strings'):
+            config._validate_resource_locations(resource_locations)
+
+
+    def test_validate_resource_locations_non_existing_resource_value(self):
+        file_ = self.create_tempfile()
+        # closing the file removes it from the filesystem
+        file_.close()
+
+        resource_locations = {'some-metric': file_.name}
+        config = ResourcesConfig()
+        with self.assertRaisesRegex(ConfigurationError, 'must be '
+                                                        'existing '
+                                                        'file paths'):
+            config._validate_resource_locations(resource_locations)
+

--- a/microsetta_public_api/tests/test_config.py
+++ b/microsetta_public_api/tests/test_config.py
@@ -11,14 +11,12 @@ class TestConfig(TempfileTestCase):
         with self.assertRaisesRegex(ConfigurationError, 'dictionary'):
             config._validate_resource_locations(resource_locations)
 
-
     def test_validate_resource_locations_non_string_resource_key(self):
         resource_locations = {9: '/some/file/path'}
         config = ResourcesConfig()
         with self.assertRaisesRegex(ConfigurationError, 'keys must be '
                                                         'strings'):
             config._validate_resource_locations(resource_locations)
-
 
     def test_validate_resource_locations_non_existing_resource_value(self):
         file_ = self.create_tempfile()
@@ -31,4 +29,3 @@ class TestConfig(TempfileTestCase):
                                                         'existing '
                                                         'file paths'):
             config._validate_resource_locations(resource_locations)
-

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -1,0 +1,137 @@
+import pandas as pd
+from pandas.util.testing import assert_series_equal
+from qiime2 import Artifact
+from q2_types.sample_data import SampleData, AlphaDiversity
+
+from microsetta_public_api.exceptions import ConfigurationError
+from microsetta_public_api.utils.testing import TempfileTestCase
+from microsetta_public_api.resources import ResourceManager
+
+
+class TestResourceManager(TempfileTestCase):
+
+    def test_update(self):
+        resources = ResourceManager(some_key='some_value')
+
+        qza_resource_fp = self.create_tempfile(suffix='.qza').name
+        qza_resource_fp2 = self.create_tempfile(suffix='.qza').name
+        test_series = pd.Series({'sample1': 7.15, 'sample2': 9.04},
+                                name='chao1')
+        test_series2 = pd.Series({'sample1': 7.16, 'sample2': 9.01},
+                                 name='faith_pd')
+        imported_artifact = Artifact.import_data(
+            "SampleData[AlphaDiversity]", test_series
+        )
+        imported_artifact.save(qza_resource_fp)
+        imported_artifact = Artifact.import_data(
+            "SampleData[AlphaDiversity]", test_series2
+        )
+        imported_artifact.save(qza_resource_fp2)
+
+        update_with = {'random-value': 7.24,
+                       'alpha_resources': {'chao1': qza_resource_fp,
+                                           'faith_pd': qza_resource_fp2,
+                                           },
+                       'other': {'dict': {'of': 'things'}},
+                       }
+        resources.update(update_with)
+
+        exp = {'some_key': 'some_value',
+               'random-value': 7.24,
+               'other': {'dict': {'of': 'things'}},
+               }
+
+        exp_alpha_resources = {'chao1': test_series,
+                               'faith_pd': test_series2,
+                               }
+        self.assertIn('alpha_resources', resources)
+        obs_alpha_resources = resources.pop('alpha_resources')
+        self.assertDictEqual(resources, exp)
+        self.assertListEqual(list(obs_alpha_resources.keys()),
+                             ['chao1', 'faith_pd'])
+        assert_series_equal(obs_alpha_resources['chao1'],
+                            exp_alpha_resources['chao1'])
+        assert_series_equal(obs_alpha_resources['faith_pd'],
+                            exp_alpha_resources['faith_pd'])
+
+    def test_update_bad_alpha_resources(self):
+        resources = ResourceManager(some_key='some_value')
+
+        qza_resource_fp = self.create_tempfile(suffix='.qza').name
+        qza_resource_fh2 = self.create_tempfile(suffix='.qza')
+        qza_resource_fp2 = qza_resource_fh2.name
+        qza_resource_fh2.close()
+        non_qza_resource_fp = self.create_tempfile(suffix='.some_ext').name
+        test_series = pd.Series({'sample1': 7.15, 'sample2': 9.04},
+                                name='chao1')
+        imported_artifact = Artifact.import_data(
+            "SampleData[AlphaDiversity]", test_series
+        )
+        imported_artifact.save(qza_resource_fp)
+        update_with = {'random-value': 7.24,
+                       'alpha_resources': {'chao1': qza_resource_fp,
+                                           'faith_pd': 9,
+                                           },
+                       'other': {'dict': {'of': 'things'}},
+                       }
+        with self.assertRaisesRegex(ValueError,
+                                    'Expected existing path with .qza'):
+            resources.update(update_with)
+
+        with self.assertRaisesRegex(ValueError,
+                                    'Expected existing path with .qza'):
+            update_with['alpha_resources']['faith_pd'] = qza_resource_fp2
+            resources.update(update_with)
+
+        with self.assertRaisesRegex(ValueError,
+                                    'Expected existing path with .qza'):
+            update_with['alpha_resources']['faith_pd'] = non_qza_resource_fp
+            resources.update(update_with)
+
+        with self.assertRaisesRegex(ValueError,
+                                    "Expected 'alpha_resources' field to "
+                                    "contain a dict. Got int"):
+            update_with['alpha_resources'] = 9
+            resources.update(update_with)
+
+    def test_parse_q2_data(self):
+        resource_filename = self.create_tempfile(suffix='.qza').name
+        test_series = pd.Series({'sample1': 7.15, 'sample2': 9.04},
+                                name='chao1')
+        imported_artifact = Artifact.import_data(
+            "SampleData[AlphaDiversity]", test_series
+        )
+        imported_artifact.save(resource_filename)
+
+        res = ResourceManager()
+        loaded_artifact = res._parse_q2_data(resource_filename,
+                                             SampleData[AlphaDiversity])
+        assert_series_equal(test_series, loaded_artifact)
+
+    def test_parse_q2_data_wrong_semantic_type(self):
+        resource_filename = self.create_tempfile(suffix='.qza').name
+        test_series = pd.Series({'feature1': 'k__1', 'feature2': 'k__2'},
+                                name='Taxon')
+        test_series.index.name = 'Feature ID'
+        imported_artifact = Artifact.import_data(
+            # the distincion here is that this is not alpha diversity
+            "FeatureData[Taxonomy]", test_series
+        )
+        imported_artifact.save(resource_filename)
+
+        res = ResourceManager()
+        with self.assertRaisesRegex(ConfigurationError,
+                                    r"Expected (.*) "
+                                    r"'SampleData\[AlphaDiversity\]'. "
+                                    r"Received 'FeatureData\[Taxonomy\]'."):
+            res._parse_q2_data(resource_filename, SampleData[AlphaDiversity])
+
+    def test_parse_q2_data_file_does_not_exist(self):
+        resource_file = self.create_tempfile(suffix='.qza')
+        resource_filename = resource_file.name
+        resource_file.close()
+
+        res = ResourceManager()
+        with self.assertRaisesRegex(ConfigurationError,
+                                    r"does not exist"):
+            res._parse_q2_data(resource_filename, SampleData[AlphaDiversity])


### PR DESCRIPTION
The goal here is to update the mechanism previously proposed, so that data can be loaded into memory for the the server a single time, as opposed to with every api call.
See this line:
https://github.com/gwarmstrong/microsetta-public-api/blob/10d7c371999b65bbf2c165f6e38b95da66eca591/microsetta_public_api/server.py#L19
