### PR TITLE
Initial taxonomy api

### DIFF
--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -205,6 +205,106 @@ paths:
           description: >
             Either `summary_statistics`, `return_raw`, or both are required to be true.
 
+  '/taxonomy/resources/available':
+    get:
+      operationId: microsetta_public_api.api.taxonomy.resources_available
+      tags:
+        - Taxonomy
+      summary: Get list of available taxonomy resources
+      description: Get list of available taxonomy resources
+      responses:
+        '200':
+          description: Successfully returned taxonomy resources
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - resources
+                properties:
+                  resources:
+                    type: array
+                    items:
+                      type: string
+                      example: "greengenes"
+                    example:
+                      - "greengenes"
+                      - "silva"
+
+  '/taxonomy/summarize_group/{resource}':
+    post:
+      operationId: microsetta_public_api.api.taxonomy.summarize_group
+      tags:
+        - Taxonomy
+      summary: Get taxonomy information for a group of samples
+      description: Get taxonomy information for a group of samples
+      parameters:
+        - in: path
+          name: resource
+          description: An identifier for a taxonomy and feature table resource
+          schema:
+            type: string
+            example: "greengenes"
+          required: true
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - sample_ids
+              properties:
+                sample_ids:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/sample_id'
+                  example:
+                    - "sample1"
+                    - "sample2"
+                    - "sample3"
+
+      responses:
+        '200':
+          description: Successfuly return taxonomy information
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - taxonomy
+                  - features
+                  - feature_values
+                  - feature_variances
+                properties:
+                  taxonomy:
+                    type: string
+                    example: "(((((feature-2)e)d,feature-1)c)b)a;"
+                  features:
+                    type: array
+                    items:
+                      type: string
+                    example:
+                      - "feature-1"
+                      - "feature-2"
+                  feature_values:
+                    type: array
+                    items:
+                      type: number
+                    example:
+                      - 0.75
+                      - 0.25
+                  feature_variances:
+                    type: array
+                    items:
+                      type: number
+                    example:
+                      - 0.05
+                      - 0.11
+
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
 components:
   parameters:
     alpha_metric:
@@ -237,12 +337,4 @@ components:
         application/json:
           schema:
             type: object
-            properties:
-              missing_ids:
-                type: array
-                description: Missing IDs.
-                items:
-                  $ref: '#/components/schemas/sample_id'
-                  example:
-                    - "sample1"
-                    - "sample2"
+            additionalProperties: true

--- a/microsetta_public_api/api/microsetta_public_api.yml
+++ b/microsetta_public_api/api/microsetta_public_api.yml
@@ -205,7 +205,7 @@ paths:
           description: >
             Either `summary_statistics`, `return_raw`, or both are required to be true.
 
-  '/taxonomy/resources/available':
+  '/taxonomy/available':
     get:
       operationId: microsetta_public_api.api.taxonomy.resources_available
       tags:

--- a/microsetta_public_api/api/taxonomy.py
+++ b/microsetta_public_api/api/taxonomy.py
@@ -1,0 +1,6 @@
+def summarize_group(body, resource):
+    pass
+
+
+def resources_available():
+    pass

--- a/microsetta_public_api/api/tests/test_api.py
+++ b/microsetta_public_api/api/tests/test_api.py
@@ -188,23 +188,6 @@ class AlphaDiversityGroupTests(AlphaDiversityTestCase):
             self.assertEqual(api_out, exp)
             self.assertEqual(response.status_code, 404)
 
-    def test_alpha_diversity_group_unknown_sample_api_bad_response(self):
-        with self.app_context():
-            bad_missing_ids = 'sample-baz-bat'
-            exp = dict(missing_ids=bad_missing_ids,
-                       error=404, text="Sample ID(s) not found for "
-                                       "metric: observed_otus")
-            self.mock_method.return_value = jsonify(exp), 404
-
-            _, self.client = self.build_app_test_client()
-
-            response = self.client.post(
-                '/api/diversity/alpha_group/observed_otus',
-                content_type='application/json',
-                data=json.dumps(self.request_content)
-            )
-            self.assertEqual(response.status_code, 500)
-
     def test_alpha_diverstiy_group_default_arguments(self):
         with self.app_context():
             self.mock_method.return_value = jsonify(self.minimal_response), 200


### PR DESCRIPTION
Here is a first draft of what the API spec for taxonomy might look like. Pretty similar to alpha. Lets a user figure out what resources are available for taxonomy, then will provide them with a summary of the taxonomies in those samples. The plan is to lean heavily on the existing taxonomy model.
