### PR TITLE
Implement table resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm project settings
+.idea

--- a/microsetta_public_api/api/diversity/tests/test_alpha.py
+++ b/microsetta_public_api/api/diversity/tests/test_alpha.py
@@ -1,8 +1,8 @@
 from microsetta_public_api.repo._alpha_repo import AlphaRepo
+from unittest.mock import patch, PropertyMock
 from microsetta_public_api.api.diversity.alpha import (
     available_metrics_alpha, get_alpha, alpha_group
 )
-from unittest.mock import patch, PropertyMock
 import numpy.testing as npt
 import pandas as pd
 import pandas.testing as pdt
@@ -13,6 +13,10 @@ from microsetta_public_api.utils.testing import MockedJsonifyTestCase
 
 
 class AlphaDiversityImplementationTests(MockedJsonifyTestCase):
+
+    # need to choose where jsonify is being loaded from
+    # see https://stackoverflow.com/a/46465025
+    jsonify_to_patch = 'microsetta_public_api.api.diversity.alpha.jsonify'
 
     @classmethod
     def setUpClass(cls):

--- a/microsetta_public_api/config.py
+++ b/microsetta_public_api/config.py
@@ -32,7 +32,5 @@ class ResourcesConfig(dict):
                                      'existing file paths.')
         return True
 
-    pass
-
 
 resources = ResourcesConfig()

--- a/microsetta_public_api/repo/tests/test_alpha_repo.py
+++ b/microsetta_public_api/repo/tests/test_alpha_repo.py
@@ -45,6 +45,7 @@ class TestAlphaRepoWithResources(TempfileTestCase):
             "SampleData[AlphaDiversity]", test_series2
         )
         imported_artifact.save(resource_filename2)
+        config.resources.clear()
         config.resources.update({
             'alpha_resources': {
                 'chao1': resource_filename1,

--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -59,10 +59,10 @@ class ResourceManager(dict):
     dict_of_qza_resources = {'alpha_resources': SampleData[AlphaDiversity]}
 
     resource_formats = {
-        'alpha_resources': ({
-            'from': Dict[str, str],
-            'to': Dict[str, _AlphaSampleData],
-        }),
+        'alpha_resources': (
+            Dict[str, str],
+            Dict[str, _AlphaSampleData],
+        ),
     }
 
     transformers = {
@@ -106,14 +106,16 @@ class ResourceManager(dict):
             raise TypeError(f'update expected at most 1 positional argument '
                             f'that is a dict. Got {args}')
 
-        for resource_name, type_ in self.dict_of_qza_resources.items():
+        for resource_name in self.resource_formats:
+            transformer = self.transformers[
+                self.resource_formats[resource_name]]
             if resource_name in other:
-                new_resource = _str_str_to_str_alpha(other[resource_name],
-                                                     resource_name)
+                new_resource = transformer(other[resource_name],
+                                           resource_name)
                 other.update(new_resource)
             if resource_name in kwargs:
-                new_resource = _str_str_to_str_alpha(kwargs[resource_name],
-                                                     resource_name)
+                new_resource = transformer(kwargs[resource_name],
+                                           resource_name)
                 kwargs.update(new_resource)
 
         return super().update(other, **kwargs)

--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -1,12 +1,8 @@
 import os
 import pandas as pd
-from copy import deepcopy
 from microsetta_public_api.exceptions import ConfigurationError
 from qiime2 import Artifact
 from q2_types.sample_data import AlphaDiversity, SampleData
-from typing import Dict, Any, NewType
-
-_AlphaSampleData = NewType('SampleData[AlphaDiversity]', Any)
 
 
 def _str_str_to_str_alpha(dict_of_qza_paths, resource_name):
@@ -56,18 +52,8 @@ def _replace_paths_with_qza(dict_of_qza_paths, name, semantic_type):
 
 class ResourceManager(dict):
 
-    dict_of_qza_resources = {'alpha_resources': SampleData[AlphaDiversity]}
-
-    resource_formats = {
-        'alpha_resources': (
-            Dict[str, str],
-            Dict[str, _AlphaSampleData],
-        ),
-    }
-
     transformers = {
-        (Dict[str, str],
-         Dict[str, _AlphaSampleData]): _str_str_to_str_alpha,
+        'alpha_resources': _str_str_to_str_alpha,
     }
 
     def update(self, *args, **kwargs):
@@ -106,9 +92,7 @@ class ResourceManager(dict):
             raise TypeError(f'update expected at most 1 positional argument '
                             f'that is a dict. Got {args}')
 
-        for resource_name in self.resource_formats:
-            transformer = self.transformers[
-                self.resource_formats[resource_name]]
+        for resource_name, transformer in self.transformers.items():
             if resource_name in other:
                 new_resource = transformer(other[resource_name],
                                            resource_name)

--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -9,8 +9,13 @@ from typing import Dict, Any, NewType
 _AlphaSampleData = NewType('SampleData[AlphaDiversity]', Any)
 
 
-def _str_str_to_str_alpha():
-    pass
+def _str_str_to_str_alpha(dict_of_qza_paths, resource_name):
+    _validate_dict_of_qza_paths(dict_of_qza_paths,
+                                resource_name)
+    new_resource = _replace_paths_with_qza(dict_of_qza_paths,
+                                           resource_name,
+                                           SampleData[AlphaDiversity])
+    return new_resource
 
 
 def _parse_q2_data(filepath, semantic_type):
@@ -103,17 +108,13 @@ class ResourceManager(dict):
 
         for resource_name, type_ in self.dict_of_qza_resources.items():
             if resource_name in other:
-                _validate_dict_of_qza_paths(other[resource_name],
-                                            resource_name)
-                other.update(_replace_paths_with_qza(other[resource_name],
-                                                     resource_name,
-                                                     type_))
+                new_resource = _str_str_to_str_alpha(other[resource_name],
+                                                     resource_name)
+                other.update(new_resource)
             if resource_name in kwargs:
-                _validate_dict_of_qza_paths(kwargs[resource_name],
-                                            resource_name)
-                kwargs.update(_replace_paths_with_qza(kwargs[resource_name],
-                                                      resource_name,
-                                                      type_))
+                new_resource = _str_str_to_str_alpha(kwargs[resource_name],
+                                                     resource_name)
+                kwargs.update(new_resource)
 
         return super().update(other, **kwargs)
 

--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -27,21 +27,25 @@ def _parse_q2_data(filepath, semantic_type):
     return data.view(pd.Series)
 
 
-def _replace_paths_with_qza(resource, name, semantic_type):
-    dict_of_qza_paths = resource[name]
+def _validate_dict_of_qza_paths(dict_of_qza_paths, name):
     if not isinstance(dict_of_qza_paths, dict):
         raise ValueError(f"Expected '{name}' field to contain a dict. "
-                         f"Got {type(resource[name]).__name__}")
-    new_resource = deepcopy(resource)
+                         f"Got {type(dict_of_qza_paths).__name__}")
     for key, value in dict_of_qza_paths.items():
         value_is_existing_qza_path = isinstance(value, str) and \
-                                     (value[-4:] == '.qza') and os.path.exists(value)
-        if value_is_existing_qza_path:
-            new_resource[name][key] = _parse_q2_data(value,
-                                                     semantic_type)
-        else:
+                                     (value[-4:] == '.qza') and \
+                                     os.path.exists(value)
+
+        if not value_is_existing_qza_path:
             raise ValueError(f'Expected existing path with .qza '
                              f'extension. Got: {value}')
+
+
+def _replace_paths_with_qza(dict_of_qza_paths, name, semantic_type):
+    new_resource = {name: dict()}
+    for key, value in dict_of_qza_paths.items():
+        new_resource[name][key] = _parse_q2_data(value,
+                                                 semantic_type)
     return new_resource
 
 
@@ -61,13 +65,13 @@ class ResourceManager(dict):
          Dict[str, _AlphaSampleData]): _str_str_to_str_alpha,
     }
 
-    def update(self, other, **kwargs):
+    def update(self, *args, **kwargs):
         """
         Updates the managers resources.
 
         Parameters
         ----------
-        other : dict
+        other : optional dict
             Resource identifier to resource mapping. 'alpha_resources' is
             reserved for a dictionary. The values in 'alpha_resources' must be
             existing file paths with a .qza extension, they will be read
@@ -89,13 +93,27 @@ class ResourceManager(dict):
 
 
         """
+        if len(args) == 1 and isinstance(args[0], dict):
+            other = args[0]
+        elif len(args) == 0:
+            other = dict()
+        else:
+            raise TypeError(f'update expected at most 1 positional argument '
+                            f'that is a dict. Got {args}')
+
         for resource_name, type_ in self.dict_of_qza_resources.items():
             if resource_name in other:
-                other = _replace_paths_with_qza(other, resource_name,
-                                                type_)
+                _validate_dict_of_qza_paths(other[resource_name],
+                                            resource_name)
+                other.update(_replace_paths_with_qza(other[resource_name],
+                                                     resource_name,
+                                                     type_))
             if resource_name in kwargs:
-                kwargs = _replace_paths_with_qza(kwargs, resource_name,
-                                                 type_)
+                _validate_dict_of_qza_paths(kwargs[resource_name],
+                                            resource_name)
+                kwargs.update(_replace_paths_with_qza(kwargs[resource_name],
+                                                      resource_name,
+                                                      type_))
 
         return super().update(other, **kwargs)
 

--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -10,7 +10,8 @@ def _dict_of_paths_to_alpha_data(dict_of_qza_paths, resource_name):
     _validate_dict_of_qza_paths(dict_of_qza_paths,
                                 resource_name)
     new_resource = _replace_paths_with_qza(dict_of_qza_paths,
-                                           SampleData[AlphaDiversity])
+                                           SampleData[AlphaDiversity],
+                                           view_type=pd.Series)
     return new_resource
 
 
@@ -43,7 +44,7 @@ def _transform_single_table(dict_, resource_name):
     return new_resource
 
 
-def _parse_q2_data(filepath, semantic_type):
+def _parse_q2_data(filepath, semantic_type, view_type=None):
     try:
         data = Artifact.load(filepath)
     except ValueError as e:
@@ -53,8 +54,10 @@ def _parse_q2_data(filepath, semantic_type):
         raise ConfigurationError(f"Expected QZA '{filepath}' to have type "
                                  f"'{semantic_type}'. "
                                  f"Received '{data.type}'.")
+    if view_type is not None:
+        data = data.view(view_type=view_type)
 
-    return data.view(pd.Series)
+    return data
 
 
 def _validate_dict_of_qza_paths(dict_of_qza_paths, name, allow_none=False,
@@ -90,11 +93,13 @@ def _validate_dict_of_qza_paths(dict_of_qza_paths, name, allow_none=False,
                              'extension. Got: {}'.format(value))
 
 
-def _replace_paths_with_qza(dict_of_qza_paths, semantic_type):
+def _replace_paths_with_qza(dict_of_qza_paths, semantic_type, view_type=None):
     new_resource = dict()
     for key, value in dict_of_qza_paths.items():
         new_resource[key] = _parse_q2_data(value,
-                                           semantic_type)
+                                           semantic_type,
+                                           view_type=view_type,
+                                           )
     return new_resource
 
 

--- a/microsetta_public_api/resources.py
+++ b/microsetta_public_api/resources.py
@@ -1,16 +1,45 @@
 import os
 import pandas as pd
+from copy import deepcopy
 from microsetta_public_api.exceptions import ConfigurationError
 from qiime2 import Artifact
 from q2_types.sample_data import AlphaDiversity, SampleData
 
 
-def _str_str_to_str_alpha(dict_of_qza_paths, resource_name):
+def _dict_of_paths_to_alpha_data(dict_of_qza_paths, resource_name):
     _validate_dict_of_qza_paths(dict_of_qza_paths,
                                 resource_name)
     new_resource = _replace_paths_with_qza(dict_of_qza_paths,
-                                           resource_name,
                                            SampleData[AlphaDiversity])
+    return new_resource
+
+
+def _transform_dict_of_table(dict_, resource_name):
+    if not isinstance(dict_, dict):
+        raise TypeError(f"Expected field '{resource_name}' to contain a "
+                        f"dictionary. Got {dict_}.")
+    new_resource = dict()
+    for table_name, attributes in dict_.items():
+        res = _transform_single_table(attributes, table_name)
+        new_resource[table_name] = res
+    return new_resource
+
+
+def _transform_single_table(dict_, resource_name):
+    _validate_dict_of_qza_paths(dict_, resource_name, allow_none=True,
+                                required_fields=['table'],
+                                non_qza_entries=['table-type']
+                                )
+    semantic_types = {
+        'table': dict_.get('table-type', "FeatureTable[Frequency]"),
+        'feature-data-taxonomy': "FeatureData[Taxonomy]",
+        'variances': "FeatureTable[Frequency]",
+    }
+    new_resource = deepcopy(dict_)
+    for key, value in dict_.items():
+        if key in semantic_types:
+            new_resource[key] = _parse_q2_data(value,
+                                               semantic_types[key])
     return new_resource
 
 
@@ -28,32 +57,52 @@ def _parse_q2_data(filepath, semantic_type):
     return data.view(pd.Series)
 
 
-def _validate_dict_of_qza_paths(dict_of_qza_paths, name):
+def _validate_dict_of_qza_paths(dict_of_qza_paths, name, allow_none=False,
+                                required_fields=None, allow_extras=False,
+                                non_qza_entries=None,
+                                ):
+    if non_qza_entries is None:
+        non_qza_entries = []
     if not isinstance(dict_of_qza_paths, dict):
         raise ValueError(f"Expected '{name}' field to contain a dict. "
                          f"Got {type(dict_of_qza_paths).__name__}")
+    if required_fields:
+        for field in required_fields:
+            if field not in dict_of_qza_paths:
+                raise ValueError(f"Did not get required field '{field}'.")
+        if not allow_extras:
+            extra_keys = list(filter(lambda x: x in set(required_fields),
+                                     dict_of_qza_paths.keys()))
+            if extra_keys:
+                raise ValueError(f"Extra keys: {extra_keys} not allowed.")
+
     for key, value in dict_of_qza_paths.items():
-        value_is_existing_qza_path = isinstance(value, str) and \
-                                     (value[-4:] == '.qza') and \
-                                     os.path.exists(value)
+        if key in non_qza_entries:
+            continue
+        is_qza = isinstance(value, str) and (value.endswith('.qza'))
+        exists = isinstance(value, str) and os.path.exists(value)
+        is_none = value is None
+        value_is_existing_qza_path = (is_qza and exists) or \
+                                     (is_none and allow_none)
 
         if not value_is_existing_qza_path:
-            raise ValueError(f'Expected existing path with .qza '
-                             f'extension. Got: {value}')
+            raise ValueError('Expected existing path with .qza '
+                             'extension. Got: {}'.format(value))
 
 
-def _replace_paths_with_qza(dict_of_qza_paths, name, semantic_type):
-    new_resource = {name: dict()}
+def _replace_paths_with_qza(dict_of_qza_paths, semantic_type):
+    new_resource = dict()
     for key, value in dict_of_qza_paths.items():
-        new_resource[name][key] = _parse_q2_data(value,
-                                                 semantic_type)
+        new_resource[key] = _parse_q2_data(value,
+                                           semantic_type)
     return new_resource
 
 
 class ResourceManager(dict):
 
     transformers = {
-        'alpha_resources': _str_str_to_str_alpha,
+        'alpha_resources': _dict_of_paths_to_alpha_data,
+        'table_resources': _transform_dict_of_table,
     }
 
     def update(self, *args, **kwargs):
@@ -77,11 +126,25 @@ class ResourceManager(dict):
 
         Examples
         --------
-        >>> resources = ResourceManager(alpha_resources={
-        ...     {'faith_pd': '/path/to/some.qza',
-        ...      'chao1': '/another/path/to/a.qza',
-        ...     }}, some_other_resource='here is a string resource')
-
+        >>> resources = ResourceManager(
+        ...     alpha_resources={
+        ...         'faith_pd': '/path/to/some.qza',
+        ...         'chao1': '/another/path/to/a.qza',
+        ...     },
+        ...     table_resources={
+        ...         'greengenes_13.8_insertion': {
+        ...             'table': '/path/to/feature-table.qza',
+        ...             'feature-data-taxonomy': '/a/feat-data-taxonomy.qza',
+        ...             'variances': '/a/variance/feature-table.qza',
+        ...         },
+        ...         'some_other_feature_table': {
+        ...             'table': '/another/path/tofeature-table.qza',
+        ...             'variances': '/a/variance/feature-table.qza',
+        ...             'table-type': 'FeatureTable[Compositional]'
+        ...         },
+        ...     }
+        ...     some_other_resource='here is a string resource',
+        ...     )
 
         """
         if len(args) == 1 and isinstance(args[0], dict):
@@ -96,11 +159,11 @@ class ResourceManager(dict):
             if resource_name in other:
                 new_resource = transformer(other[resource_name],
                                            resource_name)
-                other.update(new_resource)
+                other.update({resource_name: new_resource})
             if resource_name in kwargs:
                 new_resource = transformer(kwargs[resource_name],
                                            resource_name)
-                kwargs.update(new_resource)
+                kwargs.update({resource_name: new_resource})
 
         return super().update(other, **kwargs)
 

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -5,7 +5,7 @@ from q2_types.sample_data import SampleData, AlphaDiversity
 
 from microsetta_public_api.exceptions import ConfigurationError
 from microsetta_public_api.utils.testing import TempfileTestCase
-from microsetta_public_api.resources import ResourceManager
+from microsetta_public_api.resources import ResourceManager, _parse_q2_data
 
 
 class TestResourceManager(TempfileTestCase):
@@ -103,9 +103,8 @@ class TestResourceManager(TempfileTestCase):
         )
         imported_artifact.save(resource_filename)
 
-        res = ResourceManager()
-        loaded_artifact = res._parse_q2_data(resource_filename,
-                                             SampleData[AlphaDiversity])
+        loaded_artifact = _parse_q2_data(resource_filename,
+                                         SampleData[AlphaDiversity])
         assert_series_equal(test_series, loaded_artifact)
 
     def test_parse_q2_data_wrong_semantic_type(self):
@@ -119,19 +118,17 @@ class TestResourceManager(TempfileTestCase):
         )
         imported_artifact.save(resource_filename)
 
-        res = ResourceManager()
         with self.assertRaisesRegex(ConfigurationError,
                                     r"Expected (.*) "
                                     r"'SampleData\[AlphaDiversity\]'. "
                                     r"Received 'FeatureData\[Taxonomy\]'."):
-            res._parse_q2_data(resource_filename, SampleData[AlphaDiversity])
+            _parse_q2_data(resource_filename, SampleData[AlphaDiversity])
 
     def test_parse_q2_data_file_does_not_exist(self):
         resource_file = self.create_tempfile(suffix='.qza')
         resource_filename = resource_file.name
         resource_file.close()
 
-        res = ResourceManager()
         with self.assertRaisesRegex(ConfigurationError,
                                     r"does not exist"):
-            res._parse_q2_data(resource_filename, SampleData[AlphaDiversity])
+            _parse_q2_data(resource_filename, SampleData[AlphaDiversity])

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -85,14 +85,30 @@ class TestResourceManager(TempfileTestCase):
 
         with self.assertRaisesRegex(ValueError,
                                     'Expected existing path with .qza'):
+            update_with['faith_pd'] = qza_resource_fp2
+            resources.update(alpha_resources=update_with)
+
+        with self.assertRaisesRegex(ValueError,
+                                    'Expected existing path with .qza'):
             update_with['alpha_resources']['faith_pd'] = non_qza_resource_fp
             resources.update(update_with)
+
+        with self.assertRaisesRegex(ValueError,
+                                    'Expected existing path with .qza'):
+            update_with['faith_pd'] = non_qza_resource_fp
+            resources.update(alpha_resources=update_with)
 
         with self.assertRaisesRegex(ValueError,
                                     "Expected 'alpha_resources' field to "
                                     "contain a dict. Got int"):
             update_with['alpha_resources'] = 9
             resources.update(update_with)
+
+        with self.assertRaisesRegex(ValueError,
+                                    "Expected 'alpha_resources' field to "
+                                    "contain a dict. Got int"):
+            update_with = 9
+            resources.update(alpha_resources=update_with)
 
     def test_parse_q2_data(self):
         resource_filename = self.create_tempfile(suffix='.qza').name

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -191,7 +191,8 @@ class TestResourceManagerUpdateTables(TempfileTestCase):
         exp_table = self.table
         obs_table = new_table_config['table']
 
-        assert_frame_equal(exp_table.to_dataframe(dense=True), obs_table.to_dataframe(dense=True))
+        assert_frame_equal(exp_table.to_dataframe(dense=True),
+                           obs_table.to_dataframe(dense=True))
 
     def test_two_tables(self):
         config = {'table_resources': {

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -138,15 +138,16 @@ class TestResourceManagerUpdateTables(TempfileTestCase):
                                  ['feature-1', 'feature-2', 'feature-3'],
                                  ['sample-1', 'sample-2', 'sample-3'])
 
-        self.table_qza = Artifact.import_data(
+        self.table_artifact = Artifact.import_data(
             "FeatureTable[Frequency]", self.table
         )
-        self.taxonomy_qza = Artifact.import_data(
+        self.taxonomy_artifact = Artifact.import_data(
             "FeatureData[Taxonomy]", self.taxonomy_df,
         )
-        self.table2_qza = Artifact.import_data(
+        self.table2_artifact = Artifact.import_data(
             "FeatureTable[Frequency]", self.table2
         )
+        self.resources = ResourceManager()
 
     def test_(self):
         self.fail()
@@ -164,7 +165,8 @@ class TestResourceManagerQ2Parse(TempfileTestCase):
         imported_artifact.save(resource_filename)
 
         loaded_artifact = _parse_q2_data(resource_filename,
-                                         SampleData[AlphaDiversity])
+                                         SampleData[AlphaDiversity],
+                                         view_type=pd.Series)
         assert_series_equal(test_series, loaded_artifact)
 
     def test_parse_q2_data_wrong_semantic_type(self):
@@ -182,7 +184,8 @@ class TestResourceManagerQ2Parse(TempfileTestCase):
                                     r"Expected (.*) "
                                     r"'SampleData\[AlphaDiversity\]'. "
                                     r"Received 'FeatureData\[Taxonomy\]'."):
-            _parse_q2_data(resource_filename, SampleData[AlphaDiversity])
+            _parse_q2_data(resource_filename, SampleData[AlphaDiversity],
+                           view_type=pd.Series)
 
     def test_parse_q2_data_file_does_not_exist(self):
         resource_file = self.create_tempfile(suffix='.qza')
@@ -191,4 +194,5 @@ class TestResourceManagerQ2Parse(TempfileTestCase):
 
         with self.assertRaisesRegex(ConfigurationError,
                                     r"does not exist"):
-            _parse_q2_data(resource_filename, SampleData[AlphaDiversity])
+            _parse_q2_data(resource_filename, SampleData[AlphaDiversity],
+                           view_type=pd.Series)

--- a/microsetta_public_api/tests/test_resources.py
+++ b/microsetta_public_api/tests/test_resources.py
@@ -191,7 +191,7 @@ class TestResourceManagerUpdateTables(TempfileTestCase):
         exp_table = self.table
         obs_table = new_table_config['table']
 
-        assert_frame_equal(exp_table.to_dataframe(), obs_table.to_dataframe())
+        assert_frame_equal(exp_table.to_dataframe(dense=True), obs_table.to_dataframe(dense=True))
 
     def test_two_tables(self):
         config = {'table_resources': {
@@ -204,12 +204,12 @@ class TestResourceManagerUpdateTables(TempfileTestCase):
                               ['table1', 'table2'])
         exp_table = self.table
         obs_table = new_table_config['table1']['table']
-        assert_frame_equal(exp_table.to_dataframe(),
-                           obs_table.to_dataframe())
+        assert_frame_equal(exp_table.to_dataframe(dense=True),
+                           obs_table.to_dataframe(dense=True))
         exp_table = self.table2
         obs_table = new_table_config['table2']['table']
-        assert_frame_equal(exp_table.to_dataframe(),
-                           obs_table.to_dataframe())
+        assert_frame_equal(exp_table.to_dataframe(dense=True),
+                           obs_table.to_dataframe(dense=True))
 
     def test_table_with_taxonomy(self):
         subset_table = 'table-with-taxonomy'
@@ -225,8 +225,8 @@ class TestResourceManagerUpdateTables(TempfileTestCase):
 
         exp_table = self.table
         obs_table = new_table_config['table']
-        assert_frame_equal(exp_table.to_dataframe(),
-                           obs_table.to_dataframe())
+        assert_frame_equal(exp_table.to_dataframe(dense=True),
+                           obs_table.to_dataframe(dense=True))
 
         exp_tax = self.taxonomy_df
         obs_tax = new_table_config['feature-data-taxonomy']
@@ -247,12 +247,12 @@ class TestResourceManagerUpdateTables(TempfileTestCase):
 
         exp_table = self.table
         obs_table = new_table_config['table']
-        assert_frame_equal(exp_table.to_dataframe(),
-                           obs_table.to_dataframe())
+        assert_frame_equal(exp_table.to_dataframe(dense=True),
+                           obs_table.to_dataframe(dense=True))
         exp_var = self.table2
         obs_var = new_table_config['variances']
-        assert_frame_equal(exp_var.to_dataframe(),
-                           obs_var.to_dataframe())
+        assert_frame_equal(exp_var.to_dataframe(dense=True),
+                           obs_var.to_dataframe(dense=True))
 
     def test_table_with_taxonomy_and_variance(self):
         subset_table = 'table-with-taxonomy-and-variance'
@@ -268,12 +268,12 @@ class TestResourceManagerUpdateTables(TempfileTestCase):
 
         exp_table = self.table
         obs_table = new_table_config['table']
-        assert_frame_equal(exp_table.to_dataframe(),
-                           obs_table.to_dataframe())
+        assert_frame_equal(exp_table.to_dataframe(dense=True),
+                           obs_table.to_dataframe(dense=True))
         exp_var = self.table2
         obs_var = new_table_config['variances']
-        assert_frame_equal(exp_var.to_dataframe(),
-                           obs_var.to_dataframe())
+        assert_frame_equal(exp_var.to_dataframe(dense=True),
+                           obs_var.to_dataframe(dense=True))
         exp_tax = self.taxonomy_df
         obs_tax = new_table_config['feature-data-taxonomy']
         obs_tax['Confidence'] = obs_tax['Confidence'].astype('float')

--- a/microsetta_public_api/utils/__init__.py
+++ b/microsetta_public_api/utils/__init__.py
@@ -1,3 +1,3 @@
 from microsetta_public_api.utils._utils import jsonify
 
-__all__ = ['jsonify', 'testing']
+__all__ = ['testing', 'jsonify']

--- a/microsetta_public_api/utils/__init__.py
+++ b/microsetta_public_api/utils/__init__.py
@@ -1,1 +1,3 @@
 from microsetta_public_api.utils._utils import jsonify
+
+__all__ = ['jsonify', 'testing']

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -7,7 +7,6 @@ from unittest.case import TestCase
 import microsetta_public_api
 import microsetta_public_api.server
 import microsetta_public_api.utils._utils
-from microsetta_public_api.api.diversity import alpha as alpha_imp
 
 
 class TempfileTestCase(TestCase):

--- a/microsetta_public_api/utils/testing.py
+++ b/microsetta_public_api/utils/testing.py
@@ -3,6 +3,7 @@ import json
 import types
 import tempfile
 from unittest.case import TestCase
+from unittest.mock import patch
 
 import microsetta_public_api
 import microsetta_public_api.server
@@ -94,10 +95,11 @@ def mocked_jsonify(*args, **kwargs):
 class MockedJsonifyTestCase(TestCase):
 
     def setUp(self):
-        # monkey patch jsonify, then restore it after these tests are complete
-        self.old_jsonify = _copy_func(
-            microsetta_public_api.utils._utils.jsonify)
-        microsetta_public_api.utils._utils.jsonify = mocked_jsonify
+        self.jsonify_patcher = patch(
+            self.jsonify_to_patch,
+            new=mocked_jsonify,
+        )
+        self.mock_jsonify = self.jsonify_patcher.start()
 
     def tearDown(self):
-        microsetta_public_api.utils._utils.jsonify = self.old_jsonify
+        self.jsonify_patcher.stop()


### PR DESCRIPTION
Allows usage of the resource manager like follow:
```
        >>> resources = ResourceManager(
        ...     table_resources={
        ...         'greengenes_13.8_insertion': {
        ...             'table': '/path/to/feature-table.qza',
        ...             'feature-data-taxonomy': '/a/feat-data-taxonomy.qza',
        ...             'variances': '/a/variance/feature-table.qza',
        ...         },
        ...         'some_other_feature_table': {
        ...             'table': '/another/path/tofeature-table.qza',
        ...             'variances': '/a/variance/feature-table.qza',
        ...             'table-type': FeatureTable[Frequency],
        ...         },
        ...     }
        ...     some_other_resource='here is a string resource',
        ...     )
```
This should aid in supporting the taxonomy feature when `feature-data-taxonomy` is supplied with a table resource.